### PR TITLE
SearchMoviesUseCaseテスト

### DIFF
--- a/ExampleMVVM.xcodeproj/project.pbxproj
+++ b/ExampleMVVM.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		6C0F72E229CF0F5B0005020A /* DispatchQueueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */; };
 		6C0F72E329CF115F0005020A /* DispatchQueueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */; };
 		6C0F72E629CF12930005020A /* DispatchQueueTypeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */; };
+		BBC7C7F12CF86D76001D7DF1 /* MoviesPage+Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7C7F02CF86D76001D7DF1 /* MoviesPage+Stub.swift */; };
+		BBC7C7F32CF86E46001D7DF1 /* MoviesRepositoryMockError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC7C7F22CF86E46001D7DF1 /* MoviesRepositoryMockError.swift */; };
 		BBFA0FDC2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */; };
 		BBFA0FDE2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */; };
 		FC2B715C2156FF93002BD59E /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B715B2156FF93002BD59E /* AppAppearance.swift */; };
@@ -223,6 +225,8 @@
 		1FFFC83D221B02BA007D99D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ExampleMVVMTests/Info.plist; sourceTree = SOURCE_ROOT; };
 		6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueType.swift; sourceTree = "<group>"; };
 		6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueTypeMock.swift; sourceTree = "<group>"; };
+		BBC7C7F02CF86D76001D7DF1 /* MoviesPage+Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MoviesPage+Stub.swift"; sourceTree = "<group>"; };
+		BBC7C7F22CF86E46001D7DF1 /* MoviesRepositoryMockError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesRepositoryMockError.swift; sourceTree = "<group>"; };
 		BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesRepositoryMock.swift; sourceTree = "<group>"; };
 		BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesQueriesRepositoryMock.swift; sourceTree = "<group>"; };
 		FC2B715B2156FF93002BD59E /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
@@ -341,6 +345,7 @@
 				6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */,
 				BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */,
 				BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */,
+				BBC7C7F22CF86E46001D7DF1 /* MoviesRepositoryMockError.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -845,6 +850,7 @@
 			isa = PBXGroup;
 			children = (
 				1F7C1D17242117790014F011 /* Movie+Stub.swift */,
+				BBC7C7F02CF86D76001D7DF1 /* MoviesPage+Stub.swift */,
 			);
 			path = Stubs;
 			sourceTree = "<group>";
@@ -1106,11 +1112,13 @@
 				1F9034D1230714B900DEA4BD /* NetworkConfigurableMock.swift in Sources */,
 				6C0F72E629CF12930005020A /* DispatchQueueTypeMock.swift in Sources */,
 				1F9034DA2307238C00DEA4BD /* MoviesQueriesListViewModelTests.swift in Sources */,
+				BBC7C7F32CF86E46001D7DF1 /* MoviesRepositoryMockError.swift in Sources */,
 				1F474F2F22356C7F0092DB4B /* PosterImagesRepository.swift in Sources */,
 				1FE49D9D230AEC5D00D1D42E /* MoviesQueryListViewModel.swift in Sources */,
 				1F474F2A22356C7F0092DB4B /* Movie.swift in Sources */,
 				1F90353723076B8A00DEA4BD /* MovieDetailsViewModelTests.swift in Sources */,
 				1F474F2822356C7F0092DB4B /* Cancellable.swift in Sources */,
+				BBC7C7F12CF86D76001D7DF1 /* MoviesPage+Stub.swift in Sources */,
 				1F0CEFD023436B8B004141FA /* ConnectionError.swift in Sources */,
 				1FE49D9C230AEC5500D1D42E /* MovieDetailsViewModel.swift in Sources */,
 			);

--- a/ExampleMVVM.xcodeproj/project.pbxproj
+++ b/ExampleMVVM.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		6C0F72E229CF0F5B0005020A /* DispatchQueueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */; };
 		6C0F72E329CF115F0005020A /* DispatchQueueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */; };
 		6C0F72E629CF12930005020A /* DispatchQueueTypeMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */; };
+		BBFA0FDC2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */; };
+		BBFA0FDE2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */; };
 		FC2B715C2156FF93002BD59E /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2B715B2156FF93002BD59E /* AppAppearance.swift */; };
 		FC740818216555C500FE52A5 /* UserDefaultsMoviesQueriesStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC740817216555C500FE52A5 /* UserDefaultsMoviesQueriesStorage.swift */; };
 		FC74081A2165574400FE52A5 /* MovieQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7408192165574400FE52A5 /* MovieQuery.swift */; };
@@ -221,6 +223,8 @@
 		1FFFC83D221B02BA007D99D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ExampleMVVMTests/Info.plist; sourceTree = SOURCE_ROOT; };
 		6C0F72E129CF0F5A0005020A /* DispatchQueueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueType.swift; sourceTree = "<group>"; };
 		6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueTypeMock.swift; sourceTree = "<group>"; };
+		BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesRepositoryMock.swift; sourceTree = "<group>"; };
+		BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesQueriesRepositoryMock.swift; sourceTree = "<group>"; };
 		FC2B715B2156FF93002BD59E /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		FC740817216555C500FE52A5 /* UserDefaultsMoviesQueriesStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsMoviesQueriesStorage.swift; sourceTree = "<group>"; };
 		FC7408192165574400FE52A5 /* MovieQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieQuery.swift; sourceTree = "<group>"; };
@@ -335,6 +339,8 @@
 			isa = PBXGroup;
 			children = (
 				6C0F72E429CF12180005020A /* DispatchQueueTypeMock.swift */,
+				BBFA0FDB2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift */,
+				BBFA0FDD2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1076,6 +1082,7 @@
 				1F9034C62306FF2D00DEA4BD /* DataTransferService.swift in Sources */,
 				1F9034C42306FDFE00DEA4BD /* NetworkServiceTests.swift in Sources */,
 				1F53E2B923125FAD008D6A05 /* MoviesQueryListItemViewModel.swift in Sources */,
+				BBFA0FDC2CF1FAA4001AB1E8 /* MoviesRepositoryMock.swift in Sources */,
 				1F57F8D323C656F600981E09 /* AccessibilityIdentifier.swift in Sources */,
 				1F9035412307758D00DEA4BD /* PosterImagesRepositoryMock.swift in Sources */,
 				1F474F2E22356C7F0092DB4B /* MoviesRepository.swift in Sources */,
@@ -1084,6 +1091,7 @@
 				6C0F72E329CF115F0005020A /* DispatchQueueType.swift in Sources */,
 				1F7C1D19242117910014F011 /* Movie+Stub.swift in Sources */,
 				1F90353A2307716300DEA4BD /* MoviesListViewModelTests.swift in Sources */,
+				BBFA0FDE2CF1FBBC001AB1E8 /* MoviesQueriesRepositoryMock.swift in Sources */,
 				1F9034C72306FF2D00DEA4BD /* Endpoint.swift in Sources */,
 				1F9034CE230713FC00DEA4BD /* DataTransferServiceTests.swift in Sources */,
 				1FA53A3922F45CD9009A104C /* SearchMoviesUseCaseTests.swift in Sources */,

--- a/ExampleMVVM/Domain/UseCases/SearchMoviesUseCase.swift
+++ b/ExampleMVVM/Domain/UseCases/SearchMoviesUseCase.swift
@@ -22,6 +22,7 @@ final class DefaultSearchMoviesUseCase: SearchMoviesUseCase {
         self.moviesQueriesRepository = moviesQueriesRepository
     }
 
+    // cached: 検索履歴(MoviesPage)
     func execute(
         requestValue: SearchMoviesUseCaseRequestValue,
         cached: @escaping (MoviesPage) -> Void,

--- a/ExampleMVVM/Mocks/MoviesQueriesRepositoryMock.swift
+++ b/ExampleMVVM/Mocks/MoviesQueriesRepositoryMock.swift
@@ -1,0 +1,26 @@
+//
+//  MoviesQueriesRepositoryMock.swift
+//  ExampleMVVM
+//
+//  Created by tomo on 2024/11/23
+//
+//
+
+
+class MoviesQueriesRepositoryMock: MoviesQueriesRepository {
+    var recentQueries: [MovieQuery] = []
+    var fetchCompletionCallsCount = 0
+    var saveCompletionCallsCount = 0
+
+    func fetchRecentsQueries(
+        maxCount: Int,
+        completion: @escaping (Result<[MovieQuery], Error>) -> Void
+    ) {
+        completion(.success(recentQueries))
+        fetchCompletionCallsCount += 1
+    }
+    func saveRecentQuery(query: MovieQuery, completion: @escaping (Result<MovieQuery, Error>) -> Void) {
+        recentQueries.append(query)
+        saveCompletionCallsCount += 1
+    }
+}

--- a/ExampleMVVM/Mocks/MoviesRepositoryMock.swift
+++ b/ExampleMVVM/Mocks/MoviesRepositoryMock.swift
@@ -1,0 +1,30 @@
+//
+//  MoviesRepositoryMock.swift
+//  ExampleMVVM
+//  
+//  Created by tomo on 2024/11/23
+//  
+//
+
+
+class MoviesRepositoryMock: MoviesRepository {
+
+    var result: Result<MoviesPage, Error>
+    var fetchCompletionCallsCount = 0
+
+    init(result: Result<MoviesPage, Error>) {
+        self.result = result
+    }
+
+    func fetchMoviesList(
+        query: MovieQuery,
+        page: Int,
+        cached: @escaping (MoviesPage) -> Void,
+        completion: @escaping (Result<MoviesPage, Error>
+        ) -> Void
+    ) -> Cancellable? {
+        completion(result)
+        fetchCompletionCallsCount += 1
+        return nil
+    }
+}

--- a/ExampleMVVM/Mocks/MoviesRepositoryMockError.swift
+++ b/ExampleMVVM/Mocks/MoviesRepositoryMockError.swift
@@ -1,0 +1,12 @@
+//
+//  MoviesRepositorySuccessTestError.swift
+//  ExampleMVVM
+//  
+//  Created by tomo on 2024/11/28
+//  
+//
+
+
+enum MoviesRepositoryMockError: Error {
+        case failedFetching
+    }

--- a/ExampleMVVM/Stubs/MoviesPage+Stub.swift
+++ b/ExampleMVVM/Stubs/MoviesPage+Stub.swift
@@ -1,0 +1,20 @@
+//
+//  MoviesPageStub.swift
+//  ExampleMVVMTests
+//  
+//  Created by tomo on 2024/11/28
+//  
+//
+
+import Foundation
+
+extension MoviesPage {
+    static let mock: [MoviesPage] = {
+        let page1 = MoviesPage(page: 1, totalPages: 2, movies: [
+            Movie.stub(id: "1", title: "title1", posterPath: "/1", overview: "overview1"),
+            Movie.stub(id: "2", title: "title2", posterPath: "/2", overview: "overview2")])
+        let page2 = MoviesPage(page: 2, totalPages: 2, movies: [
+            Movie.stub(id: "3", title: "title3", posterPath: "/3", overview: "overview3")])
+        return [page1, page2]
+    }()
+}

--- a/ExampleMVVMTests/Domain/UseCases/SearchMoviesUseCaseTests.swift
+++ b/ExampleMVVMTests/Domain/UseCases/SearchMoviesUseCaseTests.swift
@@ -2,19 +2,7 @@ import XCTest
 
 class SearchMoviesUseCaseTests: XCTestCase {
 
-    static let moviesPages: [MoviesPage] = {
-        let page1 = MoviesPage(page: 1, totalPages: 2, movies: [
-            Movie.stub(id: "1", title: "title1", posterPath: "/1", overview: "overview1"),
-            Movie.stub(id: "2", title: "title2", posterPath: "/2", overview: "overview2")])
-        let page2 = MoviesPage(page: 2, totalPages: 2, movies: [
-            Movie.stub(id: "3", title: "title3", posterPath: "/3", overview: "overview3")])
-        return [page1, page2]
-    }()
-    
-    enum MoviesRepositorySuccessTestError: Error {
-        case failedFetching
-    }
-
+    let mock = MoviesPage.mock
     let requestValue = SearchMoviesUseCaseRequestValue(
         query: MovieQuery(query: "title1"),
         page: 0
@@ -25,7 +13,7 @@ class SearchMoviesUseCaseTests: XCTestCase {
         var useCaseCompletionCallsCount = 0
         let moviesQueriesRepository = MoviesQueriesRepositoryMock()
         let moviesRepository = MoviesRepositoryMock(
-            result: .success(SearchMoviesUseCaseTests.moviesPages[0])
+            result: .success(mock[0])
         )
         let useCase = DefaultSearchMoviesUseCase(
             moviesRepository: moviesRepository,
@@ -44,7 +32,6 @@ class SearchMoviesUseCaseTests: XCTestCase {
         moviesQueriesRepository.fetchRecentsQueries(maxCount: 1) { result in
             recents = (try? result.get()) ?? []
         }
-        
         XCTAssertTrue(recents.contains(MovieQuery(query: "title1")))
         XCTAssertEqual(useCaseCompletionCallsCount, 1)
         XCTAssertEqual(moviesQueriesRepository.fetchCompletionCallsCount, 1)
@@ -55,7 +42,7 @@ class SearchMoviesUseCaseTests: XCTestCase {
         //SearchMoviesUseCaseが失敗した場合に、検索クエリが「最近の検索履歴（recentqueries）」に保存されないことを確認するテストを書いてください
         // 1. MoviesQueriesRepository/MoviesRepositoryのmock
         let moviesRepositoryMock = MoviesRepositoryMock(
-            result: .failure(MoviesRepositorySuccessTestError.failedFetching)
+            result: .failure(MoviesRepositoryMockError.failedFetching)
         )
         let moviesQueriesRepositoryMock = MoviesQueriesRepositoryMock()
 

--- a/ExampleMVVMTests/Domain/UseCases/SearchMoviesUseCaseTests.swift
+++ b/ExampleMVVMTests/Domain/UseCases/SearchMoviesUseCaseTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class SearchMoviesUseCaseTests: XCTestCase {
-    
+
     static let moviesPages: [MoviesPage] = {
         let page1 = MoviesPage(page: 1, totalPages: 2, movies: [
             Movie.stub(id: "1", title: "title1", posterPath: "/1", overview: "overview1"),
@@ -14,44 +14,12 @@ class SearchMoviesUseCaseTests: XCTestCase {
     enum MoviesRepositorySuccessTestError: Error {
         case failedFetching
     }
-    
-    class MoviesQueriesRepositoryMock: MoviesQueriesRepository {
-        var recentQueries: [MovieQuery] = []
-        var fetchCompletionCallsCount = 0
-        
-        func fetchRecentsQueries(
-            maxCount: Int,
-            completion: @escaping (Result<[MovieQuery], Error>) -> Void
-        ) {
-            completion(.success(recentQueries))
-            fetchCompletionCallsCount += 1
-        }
-        func saveRecentQuery(query: MovieQuery, completion: @escaping (Result<MovieQuery, Error>) -> Void) {
-            recentQueries.append(query)
-        }
-    }
-    
-    class MoviesRepositoryMock: MoviesRepository {
-        var result: Result<MoviesPage, Error>
-        var fetchCompletionCallsCount = 0
 
-        init(result: Result<MoviesPage, Error>) {
-            self.result = result
-        }
+    let requestValue = SearchMoviesUseCaseRequestValue(
+        query: MovieQuery(query: "title1"),
+        page: 0
+    )
 
-        func fetchMoviesList(
-            query: MovieQuery,
-            page: Int,
-            cached: @escaping (MoviesPage) -> Void,
-            completion: @escaping (Result<MoviesPage, Error>
-            ) -> Void
-        ) -> Cancellable? {
-            completion(result)
-            fetchCompletionCallsCount += 1
-            return nil
-        }
-    }
-    
     func testSearchMoviesUseCase_whenSuccessfullyFetchesMoviesForQuery_thenQueryIsSavedInRecentQueries() {
         // given
         var useCaseCompletionCallsCount = 0
@@ -65,10 +33,6 @@ class SearchMoviesUseCaseTests: XCTestCase {
         )
 
         // when
-        let requestValue = SearchMoviesUseCaseRequestValue(
-            query: MovieQuery(query: "title1"),
-            page: 0
-        )
         _ = useCase.execute(
             requestValue: requestValue,
             cached: { _ in }
@@ -80,6 +44,7 @@ class SearchMoviesUseCaseTests: XCTestCase {
         moviesQueriesRepository.fetchRecentsQueries(maxCount: 1) { result in
             recents = (try? result.get()) ?? []
         }
+        
         XCTAssertTrue(recents.contains(MovieQuery(query: "title1")))
         XCTAssertEqual(useCaseCompletionCallsCount, 1)
         XCTAssertEqual(moviesQueriesRepository.fetchCompletionCallsCount, 1)
@@ -88,5 +53,24 @@ class SearchMoviesUseCaseTests: XCTestCase {
     
     func testSearchMoviesUseCase_whenFailedFetchingMoviesForQuery_thenQueryIsNotSavedInRecentQueries() {
         //SearchMoviesUseCaseが失敗した場合に、検索クエリが「最近の検索履歴（recentqueries）」に保存されないことを確認するテストを書いてください
+        // 1. MoviesQueriesRepository/MoviesRepositoryのmock
+        let moviesRepositoryMock = MoviesRepositoryMock(
+            result: .failure(MoviesRepositorySuccessTestError.failedFetching)
+        )
+        let moviesQueriesRepositoryMock = MoviesQueriesRepositoryMock()
+
+        let usecase = DefaultSearchMoviesUseCase(moviesRepository: moviesRepositoryMock, moviesQueriesRepository: moviesQueriesRepositoryMock)
+
+        // 2. usecaseのexecute
+        _ = usecase.execute(
+            requestValue: requestValue,
+            cached: { _ in },
+            completion: { _ in }
+        )
+
+        // 3. assert
+        XCTAssertEqual(moviesRepositoryMock.fetchCompletionCallsCount, 1, "fetchMoviesListが呼ばれていないため")
+        XCTAssertEqual(moviesQueriesRepositoryMock.saveCompletionCallsCount, 0, "saveRecentQueryが呼ばれていないため")
+        XCTAssertTrue(moviesQueriesRepositoryMock.recentQueries.isEmpty)
     }
 }


### PR DESCRIPTION
## 対応内容
SearchMoviesUseCaseのexecuteメソッド、失敗時のテスト

## やったこと
- MoviesQueriesRepository/MoviesRepositoryのMock実装
- テストケースの追加

## UI before / after
変更なし

## テスト
- MoviesRepositoryMockのfetchMoviesListが何回呼ばれたか
- MoviesQueriesRepositoryMockのsaveRecentQueryが何回呼ばれたか
- MoviesQueriesRepositoryMockの配列が空であるか

## その他
テストの書き方が正しいかFBお願いいたします。
ソースコードの実装については理解ができてない部分があるので
MTGに確認させてください。
